### PR TITLE
add object reference animation curve support

### DIFF
--- a/Animation/AnimationExtensions.cs
+++ b/Animation/AnimationExtensions.cs
@@ -77,5 +77,111 @@ namespace Sucrose.Animation
         {
             return animation.WithBinaryCurve(string.Empty, typeof(T), name, zero, zero);
         }
+
+        public static SucroseAnimation WithBinaryCurve(this SucroseAnimation animation, string path, Type type, string name, UnityEngine.Object zero, UnityEngine.Object one)
+        {
+            return animation.WithCurve(path, type, name, curve =>
+            {
+                curve.AddObjectKeyframe(0f, zero);
+                curve.AddObjectKeyframe(1f / 60f, one);
+            });
+        }
+
+        public static SucroseAnimation WithBinaryCurve(this SucroseAnimation animation, string path, Type type, string name, UnityEngine.Object zero)
+        {
+            return animation.WithBinaryCurve(path, type, name, zero, zero);
+        }
+
+        public static SucroseAnimation WithBinaryCurve<T>(this SucroseAnimation animation, string path, string name, UnityEngine.Object zero, UnityEngine.Object one)
+        {
+            return animation.WithBinaryCurve(path, typeof(T), name, zero, one);
+        }
+
+        public static SucroseAnimation WithBinaryCurve(this SucroseAnimation animation, Type type, string name, UnityEngine.Object zero, UnityEngine.Object one)
+        {
+            return animation.WithBinaryCurve(string.Empty, type, name, zero, one);
+        }
+
+        public static SucroseAnimation WithBinaryCurve<T>(this SucroseAnimation animation, string name, UnityEngine.Object zero, UnityEngine.Object one)
+        {
+            return animation.WithBinaryCurve(string.Empty, typeof(T), name, zero, one);
+        }
+
+        public static SucroseAnimation WithBinaryObjectCurve<T>(this SucroseAnimation animation, string path, string name, UnityEngine.Object zero)
+        {
+            return animation.WithBinaryCurve(path, typeof(T), name, zero, zero);
+        }
+
+        public static SucroseAnimation WithBinaryCurve(this SucroseAnimation animation, Type type, string name, UnityEngine.Object zero)
+        {
+            return animation.WithBinaryCurve(string.Empty, type, name, zero, zero);
+        }
+
+        public static SucroseAnimation WithBinaryCurve<T>(this SucroseAnimation animation, string name, UnityEngine.Object zero)
+        {
+            return animation.WithBinaryCurve(string.Empty, typeof(T), name, zero, zero);
+        }
+
+        public static SucroseAnimation WithBinaryCurve(this SucroseAnimation animation, string path, Type type, string name, object zero, object one)
+        {
+            var zerotype = zero.GetType();
+            var onetype = one.GetType();
+            if (zerotype != onetype)
+                throw new ArgumentException("Incongruent argument type", nameof(one));
+
+            if (zero is float or bool or int)
+            {
+                return animation.WithCurve(path, type, name, curve =>
+                {
+                    curve.AddKeyframe(0f, (float)zero);
+                    curve.AddKeyframe(1f / 60f, (float)one);
+                });
+            }
+            else if (typeof(UnityEngine.Object).IsAssignableFrom(zerotype))
+            {
+                return animation.WithCurve(path, type, name, curve =>
+                {
+                    curve.AddObjectKeyframe(0f, (UnityEngine.Object)zero);
+                    curve.AddObjectKeyframe(1f / 60f, (UnityEngine.Object)one);
+                });
+            }
+            else
+                throw new ArgumentException("Unsupported argument type", nameof(zero));
+        }
+
+        public static SucroseAnimation WithBinaryCurve(this SucroseAnimation animation, string path, Type type, string name, object zero)
+        {
+            return animation.WithBinaryCurve(path, type, name, zero, zero);
+        }
+
+        public static SucroseAnimation WithBinaryCurve<T>(this SucroseAnimation animation, string path, string name, object zero, object one)
+        {
+            return animation.WithBinaryCurve(path, typeof(T), name, zero, one);
+        }
+
+        public static SucroseAnimation WithBinaryCurve(this SucroseAnimation animation, Type type, string name, object zero, object one)
+        {
+            return animation.WithBinaryCurve(string.Empty, type, name, zero, one);
+        }
+
+        public static SucroseAnimation WithBinaryCurve<T>(this SucroseAnimation animation, string name, object zero, object one)
+        {
+            return animation.WithBinaryCurve(string.Empty, typeof(T), name, zero, one);
+        }
+
+        public static SucroseAnimation WithBinaryObjectCurve<T>(this SucroseAnimation animation, string path, string name, object zero)
+        {
+            return animation.WithBinaryCurve(path, typeof(T), name, zero, zero);
+        }
+
+        public static SucroseAnimation WithBinaryCurve(this SucroseAnimation animation, Type type, string name, object zero)
+        {
+            return animation.WithBinaryCurve(string.Empty, type, name, zero, zero);
+        }
+
+        public static SucroseAnimation WithBinaryCurve<T>(this SucroseAnimation animation, string name, object zero)
+        {
+            return animation.WithBinaryCurve(string.Empty, typeof(T), name, zero, zero);
+        }
     }
 }

--- a/Animation/SucroseAnimation.cs
+++ b/Animation/SucroseAnimation.cs
@@ -31,9 +31,17 @@ namespace Sucrose.Animation
 
         public SucroseAnimation WithCurve(string path, Type type, string name, SucroseCurveBuilder builder)
         {
-            SucroseCurve curve = new();
-            builder.Invoke(curve);
-            _clip.SetCurve(path, type, name, curve.Curve);
+            using (SucroseCurve curve = new())
+            {
+                builder.Invoke(curve);
+
+                _clip.SetCurve(path, type, name, curve.Curve);
+                if (curve.ObjectKeyframes.Count > 0)
+                {
+                    var binding = EditorCurveBinding.PPtrCurve(path, type, name);
+                    AnimationUtility.SetObjectReferenceCurve(_clip, binding, curve.ObjectKeyframes.ToArray());
+                }
+            }
             return this;
         }
 

--- a/Animation/SucroseCurve.cs
+++ b/Animation/SucroseCurve.cs
@@ -1,20 +1,42 @@
-﻿using UnityEngine;
+﻿using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Pool;
 
 namespace Sucrose.Animation
 {
-    public class SucroseCurve
+    public class SucroseCurve : IDisposable
     {
         internal AnimationCurve Curve { get; }
+        internal List<ObjectReferenceKeyframe> ObjectKeyframes { get; }
         
         internal SucroseCurve()
         {
             Curve = new AnimationCurve();
+            ObjectKeyframes = ListPool<ObjectReferenceKeyframe>.Get(); 
+            // should i use listpool here? seems like no point because this class shouldn't be processing a lot
         }
 
         public SucroseCurve AddKeyframe(float time, float value)
         {
             Curve.AddKey(time, value);
             return this;
+        }
+
+        public SucroseCurve AddObjectKeyframe(float time, UnityEngine.Object value)
+        {
+            ObjectKeyframes.Add(new()
+            {
+                time = time,
+                value = value
+            });
+            return this;
+        }
+
+        public void Dispose()
+        {
+            ListPool<ObjectReferenceKeyframe>.Release(ObjectKeyframes);
         }
     }
 }


### PR DESCRIPTION
Unsure about the optimization of [this](https://github.com/Auros/Sucrose/pull/1/files#diff-5f226227326d2f31ce94384aa53ace12f237404e33e075265916283dfd2fde1cR125) method, but it drastically simplifies things on the Flare end. If you would rather only use explicit types then its doable and should be (slightly) more optimized, but may result in a decent amount of duplicate code. Just lmk